### PR TITLE
Add react 17 as valid peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react": "^16.8.3 || ^17.0.2",
+    "react-dom": "^16.8.3 || ^17.0.2"
   }
 }


### PR DESCRIPTION
I tried it out and it works in react 17 too, so the peer dependencies should include react 17.

This makes it possible to install the package and use it with react 17 without having to use the `--force` option in `npm install`.

This is not a breaking change, and will work with [react 16](https://jubianchi.github.io/semver-check/#/^16.8.3%20||%20^17.0.2/16.8.3) and [react 17](https://jubianchi.github.io/semver-check/#/^16.8.3%20||%20^17.0.2/17.0.2).